### PR TITLE
Improve class naming and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## Unreleased
 
+* Improve class names
 * Improve formatters
 * Use coverage kit to enforce maximum coverage

--- a/README.md
+++ b/README.md
@@ -5,14 +5,6 @@ Data Table
 
 Various helpers to enter data in a tabular form and export to HTML/CSV
 
-# INSTALLATION
+# USAGE
 
-gem install data_table
-
-or add to your Gemfile:
-gem 'data_table'
-
-# SYNOPSIS
-
-require 'data_table'
-
+See tests in spec folder for basic usage

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -2,8 +2,8 @@ module DataTable
   require 'action_view'
   require 'active_support/all'
 
+  require 'data_table/table'
   require 'data_table/data_col'
-  require 'data_table/data_table'
   require 'data_table/data_row'
   require 'data_table/data_row_group'
   require 'data_table/col_group'

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -3,9 +3,9 @@ module DataTable
   require 'active_support/all'
 
   require 'data_table/table'
-  require 'data_table/data_col'
-  require 'data_table/data_row'
-  require 'data_table/data_row_group'
+  require 'data_table/col'
+  require 'data_table/row'
+  require 'data_table/row_group'
   require 'data_table/col_group'
   require 'data_table/result_group'
 

--- a/lib/data_table/col.rb
+++ b/lib/data_table/col.rb
@@ -1,5 +1,5 @@
 module DataTable
-  class DataCol
+  class Col
     include ActionView::Helpers::TagHelper
 
     attr_accessor :data, :data_type, :row, :type, :colspan, :link_to, :anchor, :options
@@ -52,7 +52,7 @@ module DataTable
     end
 
     def to_html
-      formatter = ::DataTable.formatters(:html)[@data.class]
+      formatter = DataTable.formatters(:html)[@data.class]
       content = if formatter
         result = formatter.is_a?(Symbol) ? @data.send(formatter) : formatter.call(@data)
         if result.is_a?(Hash)
@@ -79,7 +79,7 @@ module DataTable
     private
 
     def format_csv(data)
-      formatter = ::DataTable.formatters(:csv)[data.class]
+      formatter = DataTable.formatters(:csv)[data.class]
       return data unless formatter
       result = formatter.is_a?(Symbol) ? @data.send(formatter) : formatter.call(@data)
       if result.is_a?(Hash)

--- a/lib/data_table/row.rb
+++ b/lib/data_table/row.rb
@@ -1,5 +1,5 @@
 module DataTable
-  class DataRow
+  class Row
     include ActionView::Helpers::TagHelper
 
     attr_accessor :cols, :parent, :options
@@ -9,7 +9,7 @@ module DataTable
       @options = options
       @cols  = []
       row.each do |col|
-        @cols << DataCol.new(col, row, options[:type])
+        @cols << Col.new(col, row, options[:type])
       end
       self
     end

--- a/lib/data_table/row_group.rb
+++ b/lib/data_table/row_group.rb
@@ -2,7 +2,7 @@
 #
 # Can be of type: [:header, :footer, :body]
 module DataTable
-  class DataRowGroup
+  class RowGroup
     include ActionView::Helpers::TagHelper
 
     attr_accessor :children, :parent, :options
@@ -15,16 +15,16 @@ module DataTable
 
       row_group.each do |row|
         if row.is_a? Hash
-          @children << DataRow.new(row[:data], self, row.except(:data).merge(:type => type))
+          @children << Row.new(row[:data], self, row.except(:data).merge(:type => type))
         else
-          @children << DataRow.new(row, self, :type => type)
+          @children << Row.new(row, self, :type => type)
         end
       end
       self
     end
 
     def <<(child)
-      @children << DataRow.new(child, self, :type => type)
+      @children << Row.new(child, self, :type => type)
     end
 
     def to_csv

--- a/lib/data_table/table.rb
+++ b/lib/data_table/table.rb
@@ -1,5 +1,5 @@
 module DataTable
-  class DataTable
+  class Table
     include ActionView::Helpers::TagHelper
 
     attr_accessor :children, :colgroups

--- a/lib/data_table/table.rb
+++ b/lib/data_table/table.rb
@@ -12,11 +12,11 @@ module DataTable
 
     def <<(child)
       if child.is_a? Array
-        @children << DataRow.new(child, self)
+        @children << Row.new(child, self)
 
       else # hash of one or more types
         [:header, :footer, :body].each do |type|
-          @children << DataRowGroup.new(child[type], self, type) if child[type]
+          @children << RowGroup.new(child[type], self, type) if child[type]
         end
       end
     end

--- a/spec/data_table_spec.rb
+++ b/spec/data_table_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DataTable::DataTable do
+describe DataTable::Table do
   let(:row) { ['col1', 2, Money.new(3), Booking.new(42, '22TEST')] }
   let(:money_class) {
     Class.new do


### PR DESCRIPTION
Avoids some confusing and verbose cases, e.g. DataTable::DataTable and avoids inconsistencies like DataRowGroup and ColGroup (now it's RowGroup and ColGroup)